### PR TITLE
changed parameters order  of the functions appendCSV() and writeCSV()

### DIFF
--- a/libs/appendCSV.js
+++ b/libs/appendCSV.js
@@ -3,7 +3,7 @@
 var stringify = require('csv-stringify');
 var fs = require('fs');
 
-var appendCSV = function(data, path, callback){
+var appendCSV = function(path, data, callback){
 
   stringify(data, function(error, output){
 

--- a/libs/writeCSV.js
+++ b/libs/writeCSV.js
@@ -3,7 +3,7 @@
 var stringify = require('csv-stringify');
 var fs = require('fs');
 
-var writeCSV = function(data, path, callback){
+var writeCSV = function(path, data, callback){
 
 	stringify(data, function(error, output){
 


### PR DESCRIPTION
The documentation (readme.md) didn't match the actual use of appendCSV() and writeCSV() so I changed the code for a more intuitive use of the library. 

Now the order is:

`function(path, data, callback)`
